### PR TITLE
HAAR-1932: refactor GET  'client view' endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/data/repository/ClientRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/data/repository/ClientRepository.kt
@@ -6,6 +6,8 @@ import uk.gov.justice.digital.hmpps.authorizationserver.data.model.Client
 interface ClientRepository : CrudRepository<Client, String> {
   fun findClientByClientId(clientId: String): Client?
 
+  fun findFirstByClientIdStartingWithOrderByClientIdIssuedAtDesc(clientId: String): Client?
+
   fun findByClientIdStartsWithOrderByClientId(clientId: String): List<Client>
 
   fun deleteByClientId(clientId: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/resource/ClientCredentialsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/resource/ClientCredentialsController.kt
@@ -34,13 +34,13 @@ class ClientCredentialsController(
     telemetryClient.trackEvent("AuthorizationServerClientCredentialsUpdate", telemetryMap)
   }
 
-  @GetMapping("clients/client-credentials/{clientId}/view")
+  @GetMapping("base-clients/{baseClientId}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_OAUTH_ADMIN')")
-  fun viewClient(@PathVariable clientId: String): ResponseEntity<Any> {
+  fun viewClient(@PathVariable baseClientId: String): ResponseEntity<Any> {
     return ResponseEntity.ok(
       conversionService.convert(
-        clientsService.retrieveClientFullDetails(clientId),
+        clientsService.retrieveClientFullDetails(baseClientId),
         ClientViewResponse::class.java,
       ),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/service/ClientsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/service/ClientsService.kt
@@ -184,7 +184,7 @@ class ClientsService(
 
   @Transactional(readOnly = true)
   fun retrieveClientFullDetails(clientId: String): ClientComposite {
-    val clientClientConfigPair = retrieveClientWithClientConfig(clientId)
+    val clientClientConfigPair = retrieveLatestClientWithClientConfig(clientId)
     val client = clientClientConfigPair.first
     val clientConfig = clientClientConfigPair.second
     setValidDays(clientConfig)
@@ -220,6 +220,12 @@ class ClientsService(
 
   private fun retrieveClientWithClientConfig(clientId: String): Pair<Client, ClientConfig?> {
     val existingClient = clientRepository.findClientByClientId(clientId) ?: throw ClientNotFoundException(Client::class.simpleName, clientId)
+    val existingClientConfig = clientConfigRepository.findByIdOrNull(clientIdService.toBase(clientId))
+    return Pair(existingClient, existingClientConfig)
+  }
+
+  private fun retrieveLatestClientWithClientConfig(clientId: String): Pair<Client, ClientConfig?> {
+    val existingClient = clientRepository.findFirstByClientIdStartingWithOrderByClientIdIssuedAtDesc(clientId) ?: throw ClientNotFoundException(Client::class.simpleName, clientId)
     val existingClientConfig = clientConfigRepository.findByIdOrNull(clientIdService.toBase(clientId))
     return Pair(existingClient, existingClientConfig)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/integration/ClientCredentialsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/integration/ClientCredentialsControllerIntTest.kt
@@ -254,14 +254,14 @@ class ClientCredentialsControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.get().uri("/clients/client-credentials/testy/view")
+      webTestClient.get().uri("/base-clients/testy")
         .exchange()
         .expectStatus().isForbidden
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.get().uri("/clients/client-credentials/testy/view")
+      webTestClient.get().uri("/base-clients/testy")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -269,7 +269,7 @@ class ClientCredentialsControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when wrong role`() {
-      webTestClient.get().uri("/clients/client-credentials/testy/view")
+      webTestClient.get().uri("/base-clients/testy")
         .headers(setAuthorisation(roles = listOf("WRONG")))
         .exchange()
         .expectStatus().isForbidden
@@ -277,7 +277,7 @@ class ClientCredentialsControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `not found`() {
-      webTestClient.get().uri("/clients/client-credentials/not-found/view")
+      webTestClient.get().uri("/base-clients/not-found")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isNotFound
@@ -307,7 +307,7 @@ class ClientCredentialsControllerIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.get().uri("/clients/client-credentials/test-more-test/view")
+      webTestClient.get().uri("/base-clients/test-more-test")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isOk
@@ -349,7 +349,7 @@ class ClientCredentialsControllerIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.get().uri("/clients/client-credentials/test-more-test/view")
+      webTestClient.get().uri("/base-clients/test-more-test")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isOk


### PR DESCRIPTION
refactor GET '/clients/client-credentials/{clientId}/view' to 'base-clients/{baseClientId}'