### PR TITLE
HAAR-1939: refactor DELETE 'clients/{clientId}/delete'

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/resource/ClientsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/resource/ClientsController.kt
@@ -73,7 +73,7 @@ class ClientsController(
     return ResponseEntity.ok(conversionService.convert(clientsService.findClientByClientId(clientId), ClientExistsResponse::class.java))
   }
 
-  @DeleteMapping("clients/{clientId}/delete")
+  @DeleteMapping("base-clients/{baseClientId}/clients/{clientId}")
   @ResponseStatus(HttpStatus.OK)
   @PreAuthorize("hasRole('ROLE_OAUTH_ADMIN')")
   fun deleteClient(@PathVariable clientId: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/integration/ClientsControllerIntTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/authorizationserver/integration/ClientsControllerIntTest.kt
@@ -138,14 +138,14 @@ class ClientsControllerIntTest : IntegrationTestBase() {
   inner class DeleteClient {
     @Test
     fun `access forbidden when no authority`() {
-      webTestClient.delete().uri("/clients/test-client-id/delete")
+      webTestClient.delete().uri("/base-clients/test-client-id/clients/test-client-id")
         .exchange()
         .expectStatus().isForbidden
     }
 
     @Test
     fun `access forbidden when no role`() {
-      webTestClient.delete().uri("/clients/test-client-id/delete")
+      webTestClient.delete().uri("/base-clients/test-client-id/clients/test-client-id")
         .headers(setAuthorisation(roles = listOf()))
         .exchange()
         .expectStatus().isForbidden
@@ -153,7 +153,7 @@ class ClientsControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `access forbidden when wrong role`() {
-      webTestClient.delete().uri("/clients/test-client-id/delete")
+      webTestClient.delete().uri("/base-clients/test-client-id/clients/test-client-id")
         .headers(setAuthorisation(roles = listOf("WRONG")))
         .exchange()
         .expectStatus().isForbidden
@@ -161,7 +161,7 @@ class ClientsControllerIntTest : IntegrationTestBase() {
 
     @Test
     fun `unrecognised client id`() {
-      webTestClient.delete().uri("/clients/test-test/delete")
+      webTestClient.delete().uri("/base-clients/test-test/clients/test-test")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isNotFound
@@ -173,7 +173,7 @@ class ClientsControllerIntTest : IntegrationTestBase() {
       whenever(oAuthClientSecretGenerator.encode("external-client-secret")).thenReturn("encoded-client-secret")
       givenANewClientExistsWithClientId("test-test")
 
-      webTestClient.delete().uri("/clients/test-test/delete")
+      webTestClient.delete().uri("/base-clients/test-test/clients/test-test")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isOk
@@ -202,7 +202,7 @@ class ClientsControllerIntTest : IntegrationTestBase() {
         .exchange()
         .expectStatus().isOk
 
-      webTestClient.delete().uri("/clients/test-test-1/delete")
+      webTestClient.delete().uri("/base-clients/test-test/clients/test-test-1")
         .headers(setAuthorisation(roles = listOf("ROLE_OAUTH_ADMIN")))
         .exchange()
         .expectStatus().isOk


### PR DESCRIPTION
refactor DELETE 'clients/{clientId}/delete' to 'base-clients/{baseClientId}/clients/{clientId}'